### PR TITLE
Only validate NERDTree requirements in nerdtree_plugin

### DIFF
--- a/nerdtree_plugin/webdevicons.vim
+++ b/nerdtree_plugin/webdevicons.vim
@@ -9,11 +9,11 @@ if !exists('g:webdevicons_enable_nerdtree')
 endif
 
 if g:webdevicons_enable_nerdtree == 1
-   if !exists('g:NERDTreePathNotifier')
-      let g:webdevicons_enable_nerdtree = 0
-      echohl WarningMsg |
-      \ echomsg "vim-webdevicons requires a newer version of NERDTree to show glyphs in NERDTree - consider updating NERDTree"
-   endif
+  if !exists('g:NERDTreePathNotifier')
+    let g:webdevicons_enable_nerdtree = 0
+    echohl WarningMsg |
+          \ echomsg "vim-webdevicons requires a newer version of NERDTree to show glyphs in NERDTree - consider updating NERDTree."
+  endif
 endif
 
 if !exists('g:webdevicons_enable_airline_tabline')
@@ -24,12 +24,12 @@ if !exists('g:webdevicons_enable_airline_statusline')
   let g:webdevicons_enable_airline_statusline = 1
 endif
 
-function! SetupListeners()
+function! s:SetupListeners()
   call g:NERDTreePathNotifier.AddListener("init", "NERDTreeWebDevIconsRefreshListener")
   call g:NERDTreePathNotifier.AddListener("refresh", "NERDTreeWebDevIconsRefreshListener")
   call g:NERDTreePathNotifier.AddListener("refreshFlags", "NERDTreeWebDevIconsRefreshListener")
 endfunction
 
 if g:webdevicons_enable == 1 && g:webdevicons_enable_nerdtree == 1
-  call SetupListeners()
+  call s:SetupListeners()
 endif

--- a/plugin/webdevicons.vim
+++ b/plugin/webdevicons.vim
@@ -30,14 +30,6 @@ if !exists('g:webdevicons_enable_nerdtree')
   let g:webdevicons_enable_nerdtree = 1
 endif
 
-if g:webdevicons_enable_nerdtree == 1
-   if !exists('g:NERDTreePathNotifier')
-      let g:webdevicons_enable_nerdtree = 0
-      echohl WarningMsg |
-      \ echomsg "vim-webdevicons requires a newer version of NERDTree to show glyphs in NERDTree - consider updating NERDTree"
-   endif
-endif
-
 if !exists('g:webdevicons_enable_airline_tabline')
   let g:webdevicons_enable_airline_tabline = 1
 endif


### PR DESCRIPTION
When NERDTree is loaded lazily (e.g. via NeoBundle), the check would
fail during startup.

This also uses a script-local function in the plugin and fixes the
indenting of that file.